### PR TITLE
Limit role credential TTL to 1 hour (AWS default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 exp/
 .token
+vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable [changes](http://keepachangelog.com/en/1.0.0/) to this project will be documented in this file.
 
+## [2.2.1]
+
+### Changed
+
+- Fixed #26 and #27 (Limit role credential duration to AWS default of 1 hour)
+
 ## [2.2.0]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := "2.2.0"
+VERSION := "2.2.1"
 
 BUILD := $(shell git rev-parse --short HEAD)
 FLAGS	:= "-s -w -X=main.build=$(BUILD) -X=main.time=`TZ=UTC date '+%FT%TZ'` -X=main.version=$(VERSION)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon Web Services Switch User (`awsu`)
 
-`awsu` is a client-tool for advanced STS session token and role handling.  
+`awsu` is a client-tool for advanced STS session token and role handling.
 
 It has the following features:
 
@@ -34,7 +34,7 @@ With an existing file in place `awsu` can be configured to use a certain profile
 * Profiles can be choosen with `-p` or `AWS_PROFILE` (SDK standard)
 * Shared credentials location can be overridden from it's default (e.g. `~/.aws/credentials`) using `AWS_SHARED_CREDENTIALS_FILE` (SDK standard)
 * Caching can be disabled with `-n` or `AWSU_NO_CACHE`
-* Cache TTLs and the session length for session tokens and roles can be choosen with `AWSU_CACHE_SESSION_TOKEN_TTL` (default 8h) and `AWSU_CACHE_ROLE_TTL` (default 8h) - after half of that TTL has expired the cached files are considered invalid and will be refreshed; this is done to avoid issues during long running operations
+* Cache TTLs and the session length for session tokens and roles can be choosen with `AWSU_CACHE_SESSION_TOKEN_TTL` (default 8h) and `AWSU_CACHE_ROLE_TTL` (default 1h) - after half of that TTL has expired the cached files are considered invalid and will be refreshed; this is done to avoid issues during long running operations
 * Logging can be enabled with `-v` or `AWSU_VERBOSE`
 
 ## Running `awsu`

--- a/command/root.go
+++ b/command/root.go
@@ -68,7 +68,7 @@ func init() {
 
 	os.Args = doubledash.Args
 
-	rootCmd.PersistentFlags().DurationP(config.KeyCacheTTL, "t", 8*time.Hour, "time to live for cached role credentials")
+	rootCmd.PersistentFlags().DurationP(config.KeyCacheTTL, "t", 1*time.Hour, "time to live for cached role credentials")
 	viper.BindPFlag(config.KeyCacheTTL, rootCmd.PersistentFlags().Lookup(config.KeyCacheTTL))
 	viper.BindEnv(config.KeyCacheTTL, "AWSU_CACHE_ROLE_TTL")
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 4b3a0d00e18bbac452426845dbc4e8084b825d69d3c87079d59f54af8f403d95
-updated: 2018-03-17T17:58:55.724747+01:00
+hash: 56046d32d0f8d5c843bb72874365c70b18de33659bb48ef70292537d0b03d24b
+updated: 2018-06-11T19:48:55.222998199+02:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: f0872da8a448f8cb10f4f0c95c2100e4f7356448
+  version: c9af76f2478f81c6566d0f7f4d522254ec7c0b52
   subpackages:
   - aws
   - aws/arn
@@ -15,6 +15,7 @@ imports:
   - aws/credentials/ec2rolecreds
   - aws/credentials/endpointcreds
   - aws/credentials/stscreds
+  - aws/csm
   - aws/defaults
   - aws/ec2metadata
   - aws/endpoints
@@ -53,11 +54,11 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/joshdk/ykmango
-  version: b6db46b695a610f2e5a91bd994fce833cb1580f1
+  version: b656c992234c13a22221a2020f7535ac81a47187
 - name: github.com/magiconair/properties
   version: be5ece7dd465ab0765a9682137865547526d1dfb
 - name: github.com/mdp/qrterminal
-  version: cf8d9d6f3fe59f7838802a258192a926d33b0385
+  version: 23b48afd7c2267f7d331776a6fd455560d7da691
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/mapstructure
@@ -100,7 +101,7 @@ imports:
   - transform
   - unicode/norm
 - name: gopkg.in/ini.v1
-  version: 6333e38ac20b8949a8dd68baa3650f4dee8f39f0
+  version: 06f5f3d67269ccec1fe5fe4134ba6e982984f7f5
 - name: gopkg.in/yaml.v2
   version: 1be3d31502d6eabc0dd7ce5b0daab022e14a5538
 - name: rsc.io/qr
@@ -118,6 +119,6 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   - aws/credentials/stscreds
   - aws/session
 - package: github.com/joshdk/ykmango
-  version: ^0.0.0
+  version: master
 - package: github.com/pkg/errors
   version: ^0.8.0
 - package: github.com/skratchdot/open-golang


### PR DESCRIPTION
- Bump to 2.2.1
- Fixes #26 and #27 