### PR TITLE
#36 | Support named profile configs

### DIFF
--- a/config/profiles.go
+++ b/config/profiles.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"io/ioutil"
+	"strings"
 
 	"github.com/pkg/errors"
 	ini "gopkg.in/ini.v1"
@@ -53,6 +54,10 @@ func Load(files ...string) (Profiles, error) {
 
 			if name == "preview" {
 				continue
+			}
+
+			if strings.HasPrefix(name, "profile") {
+				name = strings.TrimPrefix(name, "profile ")
 			}
 
 		init:

--- a/config/testdata/credentials
+++ b/config/testdata/credentials
@@ -2,7 +2,7 @@
 aws_access_key_id=AKIAIOSFODNN7EXAMPLE
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
-[foo]
+[profile foo]
 role_arn=arn:aws:iam::123456789012:role/marketingadmin
 source_profile=default
 external_id=123456

--- a/config/testdata/merged
+++ b/config/testdata/merged
@@ -5,7 +5,7 @@ output=json
 aws_access_key_id=AKIAIOSFODNN7EXAMPLE
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
-[foo]
+[profile foo]
 role_arn=arn:aws:iam::123456789012:role/marketingadmin
 source_profile=default
 external_id=123456


### PR DESCRIPTION
This respects the config format here:
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

It also allows using export AWS_PROFILE=<profile> before using `awsu`