### PR TITLE
Add windows support

### DIFF
--- a/strategy/credentials/credentials.go
+++ b/strategy/credentials/credentials.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -115,8 +114,7 @@ func (c *Credentials) Exec(app string, args []string) error {
 
 	log.Debug(logExec, cmd, args)
 
-	return syscall.Exec(cmd, args, env.ToEnv())
-
+	return exec_(cmd, args, env.ToEnv())
 }
 
 // IsValid indicates if a loaded credential is (still) valid

--- a/strategy/credentials/credentials_nonwin.go
+++ b/strategy/credentials/credentials_nonwin.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package credentials
+
+import "syscall"
+
+func exec_(cmd string, args []string, env []string) error {
+	return syscall.Exec(cmd, args, env)
+}

--- a/strategy/credentials/credentials_win.go
+++ b/strategy/credentials/credentials_win.go
@@ -1,0 +1,17 @@
+// +build windows
+
+package credentials
+
+import (
+	"os"
+	"os/exec"
+)
+
+func exec_(cmd string, args []string, env []string) error {
+	c := exec.Command(cmd, args[1:]...)
+	c.Env = env
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}


### PR DESCRIPTION
With this change it seems like windows is fully supported.

Usually, building for all platforms on go works out of the box, but since this uses cgo, I think you need to build the windows binaries on windows (or using an appropriate xplat toolchain setup).