### PR TITLE
Ensure correct credentials when using federation links for the console

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/kreuzwerker/awsu/log"
 
 	"github.com/kreuzwerker/awsu/console"
 	"github.com/skratchdot/open-golang/open"
@@ -31,6 +32,7 @@ var consoleCmd = &cobra.Command{
 		}
 
 		if conf.Console.Open {
+			log.Info("Opening link %s", link)
 			return open.Run(link)
 		}
 

--- a/console/console.go
+++ b/console/console.go
@@ -85,11 +85,11 @@ func (c *Console) external() (string, error) {
 		return "", errors.Wrapf(err, errFederationMarshal)
 	}
 
-	url := fmt.Sprintf("https://signin.aws.amazon.com/federation?Action=getSigninToken&Session=%s", string(url.QueryEscape(string(enc))))
+	federationUrl := fmt.Sprintf("https://signin.aws.amazon.com/federation?Action=getSigninToken&Session=%s", string(url.QueryEscape(string(enc))))
 
 	var buf = bytes.NewBuffer(nil)
 
-	res, err := http.Get(url)
+	res, err := http.Get(federationUrl)
 
 	if err != nil {
 		return "", errors.Wrapf(err, errFederationRequest)
@@ -113,12 +113,12 @@ func (c *Console) external() (string, error) {
 		token       = body["SigninToken"]
 	)
 
-	url = fmt.Sprintf("https://signin.aws.amazon.com/federation?Action=login&Issuer=%s&Destination=%s&SigninToken=%s\n",
+	federationUrl = fmt.Sprintf("https://signin.aws.amazon.com/federation?Action=login&Issuer=%s&Destination=%s&SigninToken=%s",
 		issuer,
-		destination,
-		token)
+		url.QueryEscape(destination),
+		url.QueryEscape(token))
 
-	return url, nil
+	return federationUrl, nil
 
 }
 

--- a/console/console.go
+++ b/console/console.go
@@ -75,7 +75,7 @@ func (c *Console) external() (string, error) {
 
 	fep := map[string]string{
 		"sessionId":    creds.AccessKeyID,
-		"sessionKey":   creds.SessionToken,
+		"sessionKey":   creds.SecretAccessKey,
 		"sessionToken": creds.SessionToken,
 	}
 


### PR DESCRIPTION
Hi,
when using the `console` command with federated accounts the generated link is not correct as it uses the session token rather than the secret_access_key for the authentication. Also the link was not opened properly on MacOS as it ended with a newline character and the query parameters were not escaped. 

This PR adds a log output to inform users that the console is opened and it fixed the broken federation link.

Hope this helps.
Cheers, Tolleiv