### PR TITLE
fix(build): goreleaser config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           cp build/awsu-macos-latest-amd64 build/awsu_darwin_arm64
           ls -lash build
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
           version: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Setup dependencies
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
       # need to setup to avoid https://goreleaser.com/deprecations/#builds-for-darwinarm64
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Download macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           make build/awsu-linux-amd64
           mv build/awsu-linux-amd64 build/awsu-ubuntu-latest-amd64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: awsu-${{ matrix.os }}-amd64
           path: build/awsu-${{ matrix.os }}-amd64
@@ -61,12 +61,12 @@ jobs:
         with:
           go-version: 1.19
       - name: Download macos
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: awsu-macos-latest-amd64
           path: build
       - name: Download linux
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: awsu-ubuntu-latest-amd64
           path: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,3 +89,6 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+      - name: List goreleaser dist folder contents
+        run: |
+          ls -lash dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go
@@ -52,7 +52,7 @@ jobs:
     needs: [artifact-build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # need to setup to avoid https://goreleaser.com/deprecations/#builds-for-darwinarm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go
@@ -46,7 +46,7 @@ jobs:
     needs: [artifact-build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # need to setup to avoid https://goreleaser.com/deprecations/#builds-for-darwinarm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Setup dependencies
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
       # need to setup to avoid https://goreleaser.com/deprecations/#builds-for-darwinarm64
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Download macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           cp build/awsu-macos-latest-amd64 build/awsu_darwin_arm64
           ls -lash build
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           make build/awsu-linux-amd64
           mv build/awsu-linux-amd64 build/awsu-ubuntu-latest-amd64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: awsu-${{ matrix.os }}-amd64
           path: build/awsu-${{ matrix.os }}-amd64
@@ -55,12 +55,12 @@ jobs:
         with:
           go-version: 1.19
       - name: Download macos
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: awsu-macos-latest-amd64
           path: build
       - name: Download linux
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: awsu-ubuntu-latest-amd64
           path: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Setup Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ builds:
     goarch:
     - amd64
     - arm64
+    goamd64:
+    - v1
     prebuilt:
       path: build/awsu_{{ .Os }}_{{ .Arch }}
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,11 +10,12 @@ builds:
     prebuilt:
       path: build/awsu_{{ .Os }}_{{ .Arch }}
 archives:
-  - replacements:
-      linux: Linux
-      darwin: Darwin
-      amd64: x86_64
-      arm64: arm
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}arm
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
<!-- Thank you for your contribution to passgen! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

fixes the release process after `v2.3.10`


## How this PR fixes the problem?

- by updating to the latest GitHub Actions
- updating the goreleaser config by replacing deprecations. See [log](https://github.com/kreuzwerker/awsu/actions/runs/4181648712/jobs/7243941568)
- adding the property `v1` for `amd64` builds. See [docs](https://goreleaser.com/customization/builds/?h=build)

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Which issue(s) does this PR fix?

fixes #64 